### PR TITLE
Convert arbitrary Julia types to structs

### DIFF
--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -3,7 +3,7 @@ module MATLAB
     # mxarray
     export MxArray, mxClassID, mxComplexity
     export mxclassid, data_ptr
-    export classid, nrows, ncols, nelems, ndims, elsize
+    export classid, nrows, ncols, nelems, elsize
     
     export is_double, is_single
     export is_int8, is_uint8, is_int16, is_uint16
@@ -13,7 +13,7 @@ module MATLAB
     
     export mxarray, mxempty, mxsparse, delete, duplicate
     export mxcellarray, get_cell, set_cell
-    export mxstruct, nfields, get_fieldname, get_field, set_field
+    export mxstruct, mxstructarray, nfields, get_fieldname, get_field, set_field
     export jvariable, jarray, jscalar, jvector, jmatrix, jsparse, jstring, jdict
 
     # mstatments
@@ -26,7 +26,7 @@ module MATLAB
     export mxcall
     export @mput, @mget, @matlab
 
-    import Base.eltype, Base.close, Base.size, Base.copy
+    import Base.eltype, Base.close, Base.size, Base.copy, Base.ndims
 
     include("exceptions.jl")
     include("mxbase.jl")

--- a/src/mstatements.jl
+++ b/src/mstatements.jl
@@ -90,6 +90,11 @@ function write_mstatement(io::IO, ex::Expr)
         end
         print(io, "]")
 
+    elseif h == :.
+        write_mstatement(io, a[1])
+        print(io, ".")
+        print(io, string(eval(a[2])))
+
     elseif h == symbol("'") || h == symbol(".'")
         print(io, "(")
         write_mstatement(io, a[1])

--- a/test/test_mstatements.jl
+++ b/test/test_mstatements.jl
@@ -1,7 +1,7 @@
 # Testing the generation of mstatements
 
 using MATLAB
-using Test
+using Base.Test
 
 @test mstatement(:abc) == "abc"
 
@@ -31,6 +31,8 @@ using Test
 @test mstatement(:([1 2 3])) == "[1, 2, 3]"
 @test mstatement(:([x; y; z])) == "[x; y; z]"
 @test mstatement(:([1 2 3; 4 5 6])) == "[[1, 2, 3]; [4, 5, 6]]"
+
+@test mstatement(:(a.b)) == "a.b"
 
 @test mstatement(:(x')) == "(x)'"
 @test mstatement(:(x.')) == "(x).'"

--- a/test/test_mxarray.jl
+++ b/test/test_mxarray.jl
@@ -1,7 +1,7 @@
 # Unit testing for MxArray
 
 using MATLAB
-using Test
+using Base.Test
 
 m = 5
 n = 6
@@ -233,6 +233,33 @@ a = mxstruct(s)
 @test jscalar(get_field(a, "version")) == 12.0
 @test isequal(jvector(get_field(a, "data")), [1,2,3])
 delete(a)
+
+type TestType
+    name::String
+    version::Float64
+    data::Vector{Int}
+end
+t = TestType("MATLAB", 12.0, [1,2,3])
+a = mxstruct(t)
+@test is_struct(a)
+@test nfields(a) == 3
+@test jstring(get_field(a, "name")) == "MATLAB"
+@test jscalar(get_field(a, "version")) == 12.0
+@test isequal(jvector(get_field(a, "data")), [1,2,3])
+delete(a)
+
+a = mxstructarray([TestType("MATLAB", 12.0, [1,2,3]),
+    TestType("Julia", 0.2, [4,5,6])])
+@test is_struct(a)
+@test nfields(a) == 3
+@test jstring(get_field(a, 1, "name")) == "MATLAB"
+@test jscalar(get_field(a, 1, "version")) == 12.0
+@test isequal(jvector(get_field(a, 1, "data")), [1,2,3])
+@test jstring(get_field(a, 2, "name")) == "Julia"
+@test jscalar(get_field(a, 2, "version")) == 0.2
+@test isequal(jvector(get_field(a, 2, "data")), [4,5,6])
+delete(a)
+
 
 # bi-directional conversions
 


### PR DESCRIPTION
mxarray(anything) converts anything to a MATLAB struct.
mxstructarray([anything]) converts to a multidimensional struct (as
opposed to a cell array of structs).

Also includes some additional cleanup in mxarray.jl, and avoids
shadowing ndims in Base.
