### PR TITLE
min was still being called instead of minimum here

### DIFF
--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -17,7 +17,7 @@ function get_paths()
             apps = readdir("/Applications")
             filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", app), apps)
             if ~isempty(apps)
-                matlab_homepath = joinpath("/Applications", min(apps))
+                matlab_homepath = joinpath("/Applications", minimum(apps))
             end
         elseif OS_NAME == :Windows
             default_dir = Int == Int32 ? "C:\\Program Files (x86)\\MATLAB" : "C:\\Program Files\\MATLAB"


### PR DESCRIPTION
In recent Julia, MATLAB.jl does not load. It seems somebody forgot to replace `min` by `minimum` in a single place. This PR fixes it.
