### PR TITLE
Fix deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.2-
+Compat

--- a/src/MATLAB.jl
+++ b/src/MATLAB.jl
@@ -1,4 +1,5 @@
 module MATLAB
+    using Compat
 
     # mxarray
     export MxArray, mxClassID, mxComplexity

--- a/src/matfile.jl
+++ b/src/matfile.jl
@@ -90,7 +90,7 @@ end
 function read_matfile(f::MatFile)
     # return a dictionary of all variables
     names = variable_names(f)
-    r = (ASCIIString=>MxArray)[]
+    r = Dict{ASCIIString,MxArray}()
     sizehint(r, length(names))
     for nam in names
         r[nam] = get_mvariable(f, nam)

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -91,7 +91,7 @@ mxclassid(::Type{Uint64})  = mxUINT64_CLASS::Cint
 mxcomplexflag{T<:MxRealNum}(::Type{T})    = mxREAL
 mxcomplexflag{T<:MxComplexNum}(::Type{T}) = mxCOMPLEX
 
-const classid_type_map = (mxClassID=>Type)[
+const classid_type_map = @compat Dict{mxClassID,Type}(
     mxLOGICAL_CLASS => Bool,
     mxCHAR_CLASS    => Char,
     mxDOUBLE_CLASS  => Float64,
@@ -104,7 +104,7 @@ const classid_type_map = (mxClassID=>Type)[
     mxUINT32_CLASS  => Uint32,
     mxINT64_CLASS   => Int64,
     mxUINT64_CLASS  => Uint64
-]
+)
 
 function mxclassid_to_type(cid::mxClassID)
     ty = get(classid_type_map::Dict{mxClassID, Type}, cid, nothing)
@@ -670,7 +670,7 @@ function jdict(mx::MxArray)
         fx = MxArray(pv, false)
         fvals[i] = jvariable(fx)
     end
-    Dict(fnames, fvals)
+    Dict(zip(fnames, fvals))
 end
 
 function jvariable(mx::MxArray)

--- a/test/matfile.jl
+++ b/test/matfile.jl
@@ -1,12 +1,11 @@
 # Test MATLAB MAT file I/O
 
-using MATLAB
-using Base.Test
+using MATLAB, Compat, Base.Test
 
 a = Int32[1 2 3; 4 5 6]
 b = [1.2, 3.4, 5.6, 7.8]
-c = {[0., 1.], [1., 2.], [1., 2., 3.]}
-d = {"name"=>"MATLAB", "score"=>100.}
+c = Any[[0., 1.], [1., 2.], [1., 2., 3.]]
+d = @compat Dict{Any,Any}("name"=>"MATLAB", "score"=>100.)
 
 immutable S
     x::Float64

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -1,7 +1,6 @@
 # Unit testing for MxArray
 
-using MATLAB
-using Base.Test
+using MATLAB, Compat, Base.Test
 
 m = 5
 n = 6
@@ -278,7 +277,7 @@ a = mxstruct("abc", "efg", "xyz")
 @test get_fieldname(a, 3) == "xyz"
 delete(a)
 
-s = {"name"=>"MATLAB", "version"=>12.0, "data"=>[1,2,3]}
+s = @compat Dict{Any,Any}("name"=>"MATLAB", "version"=>12.0, "data"=>[1,2,3])
 a = mxstruct(s)
 @test is_struct(a)
 @test nfields(a) == 3
@@ -360,7 +359,7 @@ delete(x)
 @test y[2] == a[2]
 @test y[3] == a[3]
 
-a = {"abc"=>10.0, "efg"=>[1, 2, 3], "xyz"=>"MATLAB"}
+a = @compat Dict{Any,Any}("abc"=>10.0, "efg"=>[1, 2, 3], "xyz"=>"MATLAB")
 x = mxarray(a)
 y = jvariable(x)
 delete(x)


### PR DESCRIPTION
Unfortunately because the deprecation warning for `{...}` is in the parser, `@matlab {1, 2, 3}` still throws a warning, but `@matlab Any[1, 2, 3]` doesn't really make much sense since it's farther from MATLAB syntax.
