### PR TITLE
Hide MATLAB Command Window on Windows

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -35,6 +35,11 @@ type MSession
         else
             bufptr = convert(Ptr{Uint8}, C_NULL)
         end
+        
+        if OS_NAME == :Windows
+            # Hide the MATLAB Command Window on Windows
+            ccall(engfunc(:engSetVisible ), Cint, (Ptr{Void}, Cint), ep, 0)
+        end
 
         println("A MATLAB session is open successfully")
         new(ep, buf, bufptr)


### PR DESCRIPTION
The window will still briefly flash. I do not think there is a way around this.