### PR TITLE
WIP: Add mex interface.

### DIFF
--- a/m/Jl.m
+++ b/m/Jl.m
@@ -1,0 +1,117 @@
+classdef Jl
+
+  properties (Constant)
+
+    % using the debug version?
+    debug = false;
+
+    % the mex function handle
+    raw_call = Jl.get_mex_fn();
+
+    % julia paths
+    SUFFIX = Jl.get_suffix();
+    JULIA_TOP = 'C:/tw/Julia-0.4.0-rc2';
+    JULIA_LIB = [Jl.JULIA_TOP '/lib'];
+    JULIA_BIN = [Jl.JULIA_TOP '/bin'];
+    JULIA_IMG = [Jl.JULIA_LIB '/julia/sys' Jl.SUFFIX '.dll'];
+
+    BOOT_FILE_DIR = Jl.get_boot_file_dir();
+
+    % trick to force initialization
+    booted = Jl.boot;
+  end
+
+  methods (Static)
+
+    function info()
+      Jl.raw_call();
+    end
+
+    function val = eval(expr)
+      val = Jl.raw_call('mex_eval', expr);
+    end
+
+    function include(fn)
+      Jl.eval(['include("' fn '")']);
+    end
+
+    function v = call(fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10)
+      switch nargin
+        case 1
+          v = Jl.raw_call('mex_call', fn);
+        case 2
+          v = Jl.raw_call('mex_call', fn, a1);
+        case 3
+          v = Jl.raw_call('mex_call', fn, a1, a2);
+        case 4
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3);
+        case 5
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4);
+        case 6
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5);
+        case 7
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5, a6);
+        case 8
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5, a6, a7);
+        case 9
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5, a6, a7, a8);
+        case 10
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5, a6, a7, a8, a9);
+        case 11
+          v = Jl.raw_call('mex_call', fn, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+      end
+    end
+
+    function reboot()
+      Jl.raw_include([Jl.BOOT_FILE_DIR '/boot.jl']);
+    end
+  end
+
+  methods (Static)
+
+    function hdl = get_mex_fn()
+      if Jl.debug
+        hdl = @jl_calld;
+      else
+        hdl = @jl_call;
+      end
+    end
+
+    function sfx = get_suffix()
+      if Jl.debug
+        sfx = '-debug';
+      else
+        sfx = '';
+      end
+    end
+
+    function bf = get_boot_file_dir()
+      bits = strsplit(mfilename('fullpath'), filesep);
+      bf = strjoin([bits(1:end-1)], '/');
+    end
+
+    function raw_eval(expr)
+      Jl.raw_call(0, expr)
+    end
+
+    function raw_include(fn)
+      Jl.raw_eval(['include("' fn '")']);
+    end
+
+    function bl = boot()
+      % add julia bin directory to exe path
+      setenv('PATH', [getenv('PATH') pathsep Jl.JULIA_BIN]);
+
+      % initialize the runtime
+      Jl.raw_call('', Jl.JULIA_BIN, Jl.JULIA_IMG);
+
+      % load the user initialization file
+      Jl.raw_eval('Base.load_juliarc()')
+
+      % load the boot file
+      Jl.reboot
+
+      bl = true;
+    end
+  end
+end

--- a/m/Makefile
+++ b/m/Makefile
@@ -1,0 +1,45 @@
+CC = gcc
+MEX_EXT = mexw64
+JULIA_TOP_DIR  = C:/tw/Julia-0.5.0-dev
+JULIA_INC_DIR  = $(JULIA_TOP_DIR)/include/julia
+JULIA_BIN_DIR  = $(JULIA_TOP_DIR)/bin
+
+MATLAB_INC_DIR = "C:/Program Files/MATLAB/R2015a/extern/include"
+MATLAB_BIN_DIR = "C:/Program Files/MATLAB/R2015a/bin/win64"
+
+CCOPTS  = -I$(JULIA_INC_DIR) -I$(MATLAB_INC_DIR)
+CCOPTS += -DMATLAB_MEX_FILE
+REL_CCOPTS = -O3
+DBG_CCOPTS = -g
+
+LOPTS  = -L$(JULIA_BIN_DIR) -L$(MATLAB_BIN_DIR)
+LOPTS += -shared -lmex -lmx
+REL_LOPTS = -ljulia
+DBG_LOPTS = -ljulia-debug
+
+BASE = jl_call
+SRC = $(BASE).c
+OBJ_REL = $(BASE).o
+OBJ_DBG = $(BASE)d.o
+TGT_REL = $(BASE).$(MEX_EXT)
+TGT_DBG = $(BASE)d.$(MEX_EXT)
+TGTS = $(TGT_REL) $(TGT_DBG)
+
+.PHONY : all
+all : $(TGTS)
+
+$(TGT_REL) : $(OBJ_REL)
+	$(CC) $(LOPTS) $(REL_LOPTS) -o $@ $^
+
+$(OBJ_REL) : $(SRC)
+	$(CC) $(CCOPTS) $(REL_CCOPTS) -c -o $@ $<
+
+$(TGT_DBG) : $(OBJ_DBG)
+	$(CC) $(LOPTS) $(DBG_LOPTS) -o $@ $^
+
+$(OBJ_DBG) : $(SRC)
+	$(CC) $(CCOPTS) $(DBG_CCOPTS) -c -o $@ $<
+
+.PHONY : clean
+clean :
+	-rm $(TGTS) $(OBJ_REL) $(OBJ_DBG)

--- a/m/boot.jl
+++ b/m/boot.jl
@@ -1,0 +1,49 @@
+using MATLAB
+
+libmex = Libdl.dlopen(MATLAB.matlab_library("libmex"), Libdl.RTLD_GLOBAL | Libdl.RTLD_LAZY)
+mex_fn(fun::Symbol) = dlsym(libmex::Ptr{Void}, fun)
+
+# would be great to redirect STD[IN|OUT|ERR]...
+
+function mex_args(nrhs, prhs)
+  ins  = pointer_to_array(convert(Ptr{Ptr{Void}}, prhs), nrhs, false)
+  args = [ jvariable(MxArray(mx, false)) for mx in ins ]
+end
+
+function mex_return(nlhs, plhs, vs...)
+  @assert nlhs == length(vs)
+  outs = pointer_to_array(convert(Ptr{Ptr{Void}}, plhs), nlhs, false)
+  for i in 1:nlhs
+    mx = mxarray(vs[i])
+    mx.own = false
+    outs[i] = mx.ptr
+  end
+end
+
+function mex_showerror(e)
+  buf = IOBuffer()
+  showerror(buf, e)
+  seek(buf, 0)
+  ccall(mex_fn(:mexErrMsgTxt), Void, (Ptr{Uint8},), readall(buf))
+end
+
+# define a proper eval
+function mex_eval(nlhs::Int32, plhs::Ptr{Void}, nrhs::Int32, prhs::Ptr{Void})
+  @assert nlhs == nrhs
+  try
+    mex_return(nlhs, plhs, [ eval(parse(e)) for e in mex_args(nrhs, prhs) ]...)
+  catch e
+    mex_showerror(e)
+  end
+end
+
+# call an arbitrary julia function (or other callable)
+function mex_call(nlhs::Int32, plhs::Ptr{Void}, nrhs::Int32, prhs::Ptr{Void})
+  @assert nlhs == 1 && nrhs >= 1
+  try
+    args = mex_args(nrhs, prhs)
+    mex_return(1, plhs, eval(parse(args[1]))(args[2:end]...))
+  catch e
+    mex_showerror(e)
+  end
+end

--- a/m/jl_call.cpp
+++ b/m/jl_call.cpp
@@ -1,0 +1,86 @@
+#include <mex.h>
+#include <julia.h>
+
+// string buffers
+#define BUF_LEN 1024
+char g_msg_buf[BUF_LEN];
+char g_julia_home[BUF_LEN];
+char g_image_file[BUF_LEN];
+
+void jl_check(void *result) {
+  if(result != NULL) return;
+  jl_value_t *e = jl_exception_occurred();
+  if(e) {
+    snprintf(g_msg_buf, BUF_LEN,
+            "A julia exception of type %s occurred",
+            jl_typeof_str(e));
+    jlbacktrace();
+    jl_exception_clear();
+    mexErrMsgTxt(g_msg_buf);
+  }
+}
+
+void jl_atexit_hook_0() {
+  jl_atexit_hook(0);
+}
+
+void mexFunction(int nl, mxArray* pl[], int nr, const mxArray* pr[]) {
+
+  if (nr == 0) { // dump some info
+
+    mexPrintf("version: %s\n", jl_ver_string());
+    mexPrintf("debug build?: ");
+    if(jl_is_debugbuild()) {
+      mexPrintf("yes\n");
+    } else {
+      mexPrintf("no\n");
+    }
+    mexPrintf("home: %s\n", jl_options.julia_home);
+    mexPrintf("image: %s\n", jl_options.image_file);
+
+  } else if (mxIsChar(pr[0])) { // call a function with this name
+
+    if(mxGetDimensions(pr[0])[0] == 0) { // empty string means initialization
+
+      if (jl_is_initialized()) return;
+
+      if(nr < 3 || !mxIsChar(pr[1]) || !mxIsChar(pr[2])) {
+        mexErrMsgTxt(
+          "Initialization requires 2 string arguments:\n"
+          "\t1. The Julia lib directory;\n"
+          "\t2. The path of the system image.");
+      }
+
+      mxGetString(pr[1], g_julia_home, BUF_LEN);
+      mxGetString(pr[2], g_image_file, BUF_LEN);
+
+      libsupport_init();
+      jl_options.julia_home = g_julia_home;
+      jl_options.image_file = g_image_file;
+      julia_init(JL_IMAGE_JULIA_HOME);
+      jl_exception_clear();
+      mexAtExit(jl_atexit_hook_0);
+
+    } else {
+
+      char *fnName = mxArrayToString(pr[0]);
+      jl_function_t *fn = jl_get_function(jl_main_module, fnName);
+      mxFree(fnName);
+      if(!fn) mexErrMsgTxt("Function not found.");
+
+      jl_value_t *args[4];
+      args[0] = jl_box_int32(nl);
+      args[1] = jl_box_voidpointer(pl);
+      args[2] = jl_box_int32(nr-1);
+      args[3] = jl_box_voidpointer(pr+1);
+      jl_check(jl_call(fn, args, 4));
+    }
+  } else { // evaluate the remaining arguments as strings
+    for (int i = 1; i < nr; ++i) {
+      char *expr = mxArrayToString(pr[i]);
+      void *r = jl_eval_string(expr);
+      mxFree(expr);
+      jl_check(r);
+    }
+  }
+}


### PR DESCRIPTION
This adds the ability to call julia from matlab through a mex function.

- [x] Implement basic functionality.
- Test basic functionality on:
    - [x] Windows,
    - [ ] Mac OS X,
    - [ ] *nix.
- [ ] Automate the build of the mex file.
- [ ] Write documentation.
- [ ] Add some automated tests.

I'm actually hoping I might be able to get this merged into master before having completed all of these, so that it will be easier for users to test things out on different platforms. This should be a low-risk merge, as all the new stuff is in a directory that is ignored by the julia package, and there are currently no changes to the package code itself.

The one thing that certainly needs to be done before merging into master is to add some basic documentation.