### PR TITLE
Replace deprecated types in v0.4 of Julia, Uint->UInt, String->Abstra…

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -197,7 +197,7 @@ function make_getvar_statement(ex::Expr)
     :( $(v) = MATLAB.get_variable($(Meta.quot(v)), $(k)) )
 end
 
-function _mget_multi(vs::Union{Symbol, Expr}...)
+@compat function _mget_multi(vs::Union{Symbol, Expr}...)
     nv = length(vs)
     if nv == 1
         make_getvar_statement(vs[1])

--- a/src/engine.jl
+++ b/src/engine.jl
@@ -11,8 +11,8 @@ const default_output_buffer_size = 64 * 1024
 
 type MSession
     ptr::Ptr{Void}
-    buffer::Vector{Uint8}
-    bufptr::Ptr{Uint8}
+    buffer::Vector{UInt8}
+    bufptr::Ptr{UInt8}
 
     function MSession(bufsize::Integer)
         global libeng
@@ -21,19 +21,19 @@ type MSession
         end
         @assert libeng != C_NULL
 
-        ep = ccall(engfunc(:engOpen), Ptr{Void}, (Ptr{Uint8},), default_startcmd)
+        ep = ccall(engfunc(:engOpen), Ptr{Void}, (Ptr{UInt8},), default_startcmd)
         if ep == C_NULL
             throw(MEngineError("Failed to open a MATLAB engine session."))
         end
 
-        buf = Array(Uint8, bufsize)
+        buf = Array(UInt8, bufsize)
 
         if bufsize > 0
             bufptr = pointer(buf)
-            ccall(engfunc(:engOutputBuffer), Cint, (Ptr{Void}, Ptr{Uint8}, Cint),
+            ccall(engfunc(:engOutputBuffer), Cint, (Ptr{Void}, Ptr{UInt8}, Cint),
                 ep, bufptr, bufsize)
         else
-            bufptr = convert(Ptr{Uint8}, C_NULL)
+            bufptr = convert(Ptr{UInt8}, C_NULL)
         end
         
         if OS_NAME == :Windows
@@ -102,13 +102,13 @@ function eval_string(session::MSession, stmt::ASCIIString)
     @assert libeng::Ptr{Void} != C_NULL
 
     r::Cint = ccall(engfunc(:engEvalString), Cint,
-        (Ptr{Void}, Ptr{Uint8}), session.ptr, stmt)
+        (Ptr{Void}, Ptr{UInt8}), session.ptr, stmt)
 
     if r != 0
         throw(MEngineError("Invalid engine session."))
     end
 
-    bufptr::Ptr{Uint8} = session.bufptr
+    bufptr::Ptr{UInt8} = session.bufptr
     if bufptr != C_NULL
         bs = bytestring(bufptr)
         if ~isempty(bs)
@@ -126,7 +126,7 @@ function put_variable(session::MSession, name::Symbol, v::MxArray)
     @assert libeng::Ptr{Void} != C_NULL
 
     r = ccall(engfunc(:engPutVariable), Cint,
-        (Ptr{Void}, Ptr{Uint8}, Ptr{Void}), session.ptr, string(name), v.ptr)
+        (Ptr{Void}, Ptr{UInt8}, Ptr{Void}), session.ptr, string(name), v.ptr)
 
     if r != 0
         throw(MEngineError("Failed to put the variable $(name) into a MATLAB session."))
@@ -143,7 +143,7 @@ function get_mvariable(session::MSession, name::Symbol)
     @assert libeng::Ptr{Void} != C_NULL
 
     pv = ccall(engfunc(:engGetVariable), Ptr{Void},
-        (Ptr{Void}, Ptr{Uint8}), session.ptr, string(name))
+        (Ptr{Void}, Ptr{UInt8}), session.ptr, string(name))
 
     if pv == C_NULL
         throw(MEngineError("Failed to get the variable $(name) from a MATLAB session."))
@@ -197,7 +197,7 @@ function make_getvar_statement(ex::Expr)
     :( $(v) = MATLAB.get_variable($(Meta.quot(v)), $(k)) )
 end
 
-function _mget_multi(vs::Union(Symbol, Expr)...)
+function _mget_multi(vs::Union{Symbol, Expr}...)
     nv = length(vs)
     if nv == 1
         make_getvar_statement(vs[1])

--- a/src/matstr.jl
+++ b/src/matstr.jl
@@ -9,7 +9,7 @@ end
 DumbParserState() = DumbParserState(0, false)
 
 # Returns true if an = is encountered and updates pstate
-function dumb_parse!(pstate::DumbParserState, str::String)
+function dumb_parse!(pstate::DumbParserState, str::AbstractString)
     paren_depth = pstate.paren_depth
     in_string = pstate.in_string
     x = '\0'
@@ -52,9 +52,9 @@ end
 # assignment and use status
 function check_assignment(interp, i)
     # Go back to the last newline
-    before = String[]
+    before = AbstractString[]
     for j = i-1:-1:1
-        if isa(interp[j], String)
+        if isa(interp[j], AbstractString)
             sp = split(interp[j], "\n")
             unshift!(before, sp[end])
             for k = length(sp)-1:-1:1
@@ -70,10 +70,10 @@ function check_assignment(interp, i)
     (dumb_parse!(pstate, join(before)) || pstate.paren_depth > 1) && return (false, true)
 
     # Go until the next newline or comment
-    after = String[]
+    after = AbstractString[]
     both_sides = false
     for j = i+1:length(interp)
-        if isa(interp[j], String)
+        if isa(interp[j], AbstractString)
             sp = split(interp[j], "\n")
             push!(after, sp[1])
             for k = 2:length(sp)
@@ -94,7 +94,7 @@ end
 function do_mat_str(ex)
     # Hack to do interpolation
     interp = parse(string("\"\"\"", replace(ex, "\"\"\"", "\\\"\"\""), "\"\"\""))
-    if isa(interp, String)
+    if isa(interp, AbstractString)
         interp = [interp]
     elseif interp.head == :string
         interp = interp.args
@@ -111,7 +111,7 @@ function do_mat_str(ex)
     assignedvars = Set{Symbol}()
     varmap = Dict{Symbol,Symbol}()
     for i = 1:length(interp)
-        if !isa(interp[i], String)
+        if !isa(interp[i], AbstractString)
             # Don't put the same symbol to MATLAB twice
             if haskey(varmap, interp[i])
                 var = varmap[interp[i]]
@@ -142,7 +142,7 @@ function do_mat_str(ex)
     unshift!(interp, "clear ans;\nmatlab_jl_has_ans = 0;\n")
 
     # Add a semicolon to the end of the last statement to suppress output
-    isa(interp[end], String) && (interp[end] = rstrip(interp[end]))
+    isa(interp[end], AbstractString) && (interp[end] = rstrip(interp[end]))
     push!(interp, ";")
 
     # Figure out if `ans` exists in code to avoid an error if it doesn't

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -38,9 +38,9 @@ copy(mx::MxArray) = duplicate(mx)
 
 # functions to create mxArray from Julia values/arrays
 
-MxRealNum = Union(Float64,Float32,Int32,Uint32,Int64,Uint64,Int16,Uint16,Int8,Uint8,Bool)
-MxComplexNum = Union(Complex64, Complex128)
-MxNum = Union(MxRealNum, MxComplexNum)
+MxRealNum = Union{Float64,Float32,Int32,UInt32,Int64,UInt64,Int16,UInt16,Int8,UInt8,Bool}
+MxComplexNum = Union{Complex64, Complex128}
+MxNum = Union{MxRealNum, MxComplexNum}
 
 ###########################################################
 #
@@ -48,7 +48,7 @@ MxNum = Union(MxRealNum, MxComplexNum)
 #
 ###########################################################
 
-typealias mwSize Uint
+typealias mwSize UInt
 typealias mwIndex Int
 typealias mxClassID Cint
 typealias mxComplexity Cint
@@ -77,16 +77,16 @@ const mxREAL    = convert(mxComplexity, 0)
 const mxCOMPLEX = convert(mxComplexity, 1)
 
 mxclassid(::Type{Bool})    = mxLOGICAL_CLASS::Cint
-mxclassid(::Union(Type{Float64}, Type{Complex128})) = mxDOUBLE_CLASS::Cint
-mxclassid(::Union(Type{Float32}, Type{Complex64})) = mxSINGLE_CLASS::Cint
+mxclassid(::Union{Type{Float64}, Type{Complex128}}) = mxDOUBLE_CLASS::Cint
+mxclassid(::Union{Type{Float32}, Type{Complex64}}) = mxSINGLE_CLASS::Cint
 mxclassid(::Type{Int8})    = mxINT8_CLASS::Cint
-mxclassid(::Type{Uint8})   = mxUINT8_CLASS::Cint
+mxclassid(::Type{UInt8})   = mxUINT8_CLASS::Cint
 mxclassid(::Type{Int16})   = mxINT16_CLASS::Cint
-mxclassid(::Type{Uint16})  = mxUINT16_CLASS::Cint
+mxclassid(::Type{UInt16})  = mxUINT16_CLASS::Cint
 mxclassid(::Type{Int32})   = mxINT32_CLASS::Cint
-mxclassid(::Type{Uint32})  = mxUINT32_CLASS::Cint
+mxclassid(::Type{UInt32})  = mxUINT32_CLASS::Cint
 mxclassid(::Type{Int64})   = mxINT64_CLASS::Cint
-mxclassid(::Type{Uint64})  = mxUINT64_CLASS::Cint
+mxclassid(::Type{UInt64})  = mxUINT64_CLASS::Cint
 
 mxcomplexflag{T<:MxRealNum}(::Type{T})    = mxREAL
 mxcomplexflag{T<:MxComplexNum}(::Type{T}) = mxCOMPLEX
@@ -97,13 +97,13 @@ const classid_type_map = @compat Dict{mxClassID,Type}(
     mxDOUBLE_CLASS  => Float64,
     mxSINGLE_CLASS  => Float32,
     mxINT8_CLASS    => Int8,
-    mxUINT8_CLASS   => Uint8,
+    mxUINT8_CLASS   => UInt8,
     mxINT16_CLASS   => Int16,
-    mxUINT16_CLASS  => Uint16,
+    mxUINT16_CLASS  => UInt16,
     mxINT32_CLASS   => Int32,
-    mxUINT32_CLASS  => Uint32,
+    mxUINT32_CLASS  => UInt32,
     mxINT64_CLASS   => Int64,
-    mxUINT64_CLASS  => Uint64
+    mxUINT64_CLASS  => UInt64
 )
 
 function mxclassid_to_type(cid::mxClassID)
@@ -171,13 +171,13 @@ macro mxget_attr(fun, ret)
 end
 
 classid(mx::MxArray) = @mxget_attr(_mx_get_classid, mxClassID)
-nrows(mx::MxArray)   = convert(Int, @mxget_attr(_mx_get_m, Uint))
-ncols(mx::MxArray)   = convert(Int, @mxget_attr(_mx_get_n, Uint))
-nelems(mx::MxArray)  = convert(Int, @mxget_attr(_mx_get_nelems, Uint))
+nrows(mx::MxArray)   = convert(Int, @mxget_attr(_mx_get_m, UInt))
+ncols(mx::MxArray)   = convert(Int, @mxget_attr(_mx_get_n, UInt))
+nelems(mx::MxArray)  = convert(Int, @mxget_attr(_mx_get_nelems, UInt))
 ndims(mx::MxArray)   = convert(Int, @mxget_attr(_mx_get_ndims, mwSize))
 
 eltype(mx::MxArray)  = mxclassid_to_type(classid(mx))
-elsize(mx::MxArray)  = convert(Int, @mxget_attr(_mx_get_elemsize, Uint))
+elsize(mx::MxArray)  = convert(Int, @mxget_attr(_mx_get_elemsize, UInt))
 data_ptr(mx::MxArray) = convert(Ptr{eltype(mx)}, @mxget_attr(_mx_get_data, Ptr{Void}))
 real_ptr(mx::MxArray) = convert(Ptr{eltype(mx)}, @mxget_attr(_mx_get_pr, Ptr{Void}))
 imag_ptr(mx::MxArray) = convert(Ptr{eltype(mx)}, @mxget_attr(_mx_get_pi, Ptr{Void}))
@@ -326,7 +326,7 @@ mxarray{T<:MxComplexNum}(x::T) = mxarray([x])
 
 function mxarray{T<:MxRealNum}(a::Array{T})
     mx = mxarray(T, size(a))
-    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint),
+    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt),
         data_ptr(mx), a, length(a) * sizeof(T))
     mx
 end
@@ -381,10 +381,10 @@ function _copy_sparse_mat{V,I}(a::SparseMatrixCSC{V,I},
         jc[i] = colptr[i] - 1
     end
     
-    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint), pr_p, v, nnz * sizeof(V))
+    ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt), pr_p, v, nnz * sizeof(V))
 end
 
-function mxarray{V<:Union(Float64,Bool),I}(a::SparseMatrixCSC{V,I})
+function mxarray{V<:Union{Float64,Bool},I}(a::SparseMatrixCSC{V,I})
     m::Int = a.m
     n::Int = a.n
     nnz = length(a.nzval)
@@ -404,7 +404,7 @@ end
 # char arrays and string
 
 function mxarray(s::ASCIIString)
-    pm = ccall(_mx_create_string, Ptr{Void}, (Ptr{Uint8},), s)
+    pm = ccall(_mx_create_string, Ptr{Void}, (Ptr{UInt8},), s)
     MxArray(pm)
 end
 
@@ -442,9 +442,9 @@ mxarray(a::Array) = mxcellarray(a)
 
 function _fieldname_array(fieldnames::ASCIIString...)
     n = length(fieldnames)
-    a = Array(Ptr{Uint8}, n)
+    a = Array(Ptr{UInt8}, n)
     for i = 1 : n
-        a[i] = unsafe_convert(Ptr{Uint8}, fieldnames[i])
+        a[i] = unsafe_convert(Ptr{UInt8}, fieldnames[i])
     end
     a
 end
@@ -452,7 +452,7 @@ end
 function mxstruct(fns::Vector{ASCIIString})
     a = _fieldname_array(fns...)
     pm = ccall(_mx_create_struct_matrix, Ptr{Void}, 
-        (mwSize, mwSize, Cint, Ptr{Ptr{Uint8}}), 
+        (mwSize, mwSize, Cint, Ptr{Ptr{UInt8}}), 
         1, 1, length(a), a)
     MxArray(pm)
 end
@@ -460,7 +460,7 @@ end
 function mxstruct(fn1::ASCIIString, fnr::ASCIIString...)
     a = _fieldname_array(fn1, fnr...)
     pm = ccall(_mx_create_struct_matrix, Ptr{Void}, 
-        (mwSize, mwSize, Cint, Ptr{Ptr{Uint8}}), 
+        (mwSize, mwSize, Cint, Ptr{Ptr{UInt8}}), 
         1, 1, length(a), a)
     MxArray(pm)
 end
@@ -468,14 +468,14 @@ end
 function set_field(mx::MxArray, i::Integer, f::ASCIIString, v::MxArray)
     v.own = false
     ccall(_mx_set_field, Void, 
-        (Ptr{Void}, mwIndex, Ptr{Uint8}, Ptr{Void}), 
+        (Ptr{Void}, mwIndex, Ptr{UInt8}, Ptr{Void}), 
         mx.ptr, i-1, f, v.ptr)
 end
 
 set_field(mx::MxArray, f::ASCIIString, v::MxArray) = set_field(mx, 1, f, v)
 
 function get_field(mx::MxArray, i::Integer, f::ASCIIString)
-    pm = ccall(_mx_get_field, Ptr{Void}, (Ptr{Void}, mwIndex, Ptr{Uint8}), 
+    pm = ccall(_mx_get_field, Ptr{Void}, (Ptr{Void}, mwIndex, Ptr{UInt8}), 
         mx.ptr, i-1, f)
     if pm == C_NULL
         throw(ArgumentError("Failed to get field."))
@@ -498,13 +498,13 @@ get_field(mx::MxArray, fn::Integer) = get_field(mx, 1, fn)
 
 
 function get_fieldname(mx::MxArray, i::Integer)
-    p = ccall(_mx_get_fieldname, Ptr{Uint8}, (Ptr{Void}, Cint), 
+    p = ccall(_mx_get_fieldname, Ptr{UInt8}, (Ptr{Void}, Cint), 
         mx.ptr, i-1)
     bytestring(p)
 end
 
 if VERSION >= v"0.4.0-dev+980"
-    typealias Pairs Union(Pair,NTuple{2})
+    typealias Pairs Union{Pair,NTuple{2}}
 else
     typealias Pairs NTuple{2}
 end
@@ -539,7 +539,7 @@ function mxstructarray{T}(d::Array{T})
     a = _fieldname_array(names_str...)
 
     pm = ccall(_mx_create_struct_array, Ptr{Void}, (mwSize, Ptr{mwSize}, Cint,
-        Ptr{Ptr{Uint8}}), ndims(d), _dims_to_mwSize(size(d)), length(a), a)
+        Ptr{Ptr{UInt8}}), ndims(d), _dims_to_mwSize(size(d)), length(a), a)
     mx = MxArray(pm)
 
     for i = 1:length(d), j = 1:length(names)
@@ -564,7 +564,7 @@ const _mx_get_string = mxfunc(:mxGetString_730)
 # use deep-copy from MATLAB variable to Julia array
 # in practice, MATLAB variable often has shorter life-cycle
 
-function _jarrayx(fun::String, mx::MxArray, siz::Tuple)
+function _jarrayx(fun::AbstractString, mx::MxArray, siz::Tuple)
     if is_numeric(mx) || is_logical(mx)
         @assert !is_sparse(mx)
         T = eltype(mx)
@@ -575,7 +575,7 @@ function _jarrayx(fun::String, mx::MxArray, siz::Tuple)
         else
             a = Array(T, siz)
             if !isempty(a)
-                ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, Uint), 
+                ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt), 
                     a, data_ptr(mx), sizeof(T) * length(a))
             end
         end
@@ -655,8 +655,8 @@ function jstring(mx::MxArray)
         throw(ArgumentError("jstring only applies to strings (i.e. char vectors)."))
     end
     len = ncols(mx) + 2
-    tmp = Array(Uint8, len)
-    ccall(_mx_get_string, Cint, (Ptr{Void}, Ptr{Uint8}, mwSize), 
+    tmp = Array(UInt8, len)
+    ccall(_mx_get_string, Cint, (Ptr{Void}, Ptr{UInt8}, mwSize), 
         mx.ptr, tmp, len)
     bytestring(pointer(tmp))
 end
@@ -706,7 +706,7 @@ jvariable(mx::MxArray, ty::Type{Array})  = jarray(mx)
 jvariable(mx::MxArray, ty::Type{Vector}) = jvector(mx)
 jvariable(mx::MxArray, ty::Type{Matrix}) = jmatrix(mx)
 jvariable(mx::MxArray, ty::Type{Number}) = jscalar(mx)::Number
-jvariable(mx::MxArray, ty::Type{String}) = jstring(mx)::ASCIIString
+jvariable(mx::MxArray, ty::Type{AbstractString}) = jstring(mx)::ASCIIString
 jvariable(mx::MxArray, ty::Type{ASCIIString}) = jstring(mx)::ASCIIString
 jvariable(mx::MxArray, ty::Type{Dict}) = jdict(mx)
 jvariable(mx::MxArray, ty::Type{SparseMatrixCSC}) = jsparse(mx)

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -38,9 +38,9 @@ copy(mx::MxArray) = duplicate(mx)
 
 # functions to create mxArray from Julia values/arrays
 
-MxRealNum = Union{Float64,Float32,Int32,UInt32,Int64,UInt64,Int16,UInt16,Int8,UInt8,Bool}
-MxComplexNum = Union{Complex64, Complex128}
-MxNum = Union{MxRealNum, MxComplexNum}
+@compat MxRealNum = Union{Float64,Float32,Int32,UInt32,Int64,UInt64,Int16,UInt16,Int8,UInt8,Bool}
+@compat MxComplexNum = Union{Complex64, Complex128}
+@compat MxNum = Union{MxRealNum, MxComplexNum}
 
 ###########################################################
 #
@@ -77,8 +77,8 @@ const mxREAL    = convert(mxComplexity, 0)
 const mxCOMPLEX = convert(mxComplexity, 1)
 
 mxclassid(::Type{Bool})    = mxLOGICAL_CLASS::Cint
-mxclassid(::Union{Type{Float64}, Type{Complex128}}) = mxDOUBLE_CLASS::Cint
-mxclassid(::Union{Type{Float32}, Type{Complex64}}) = mxSINGLE_CLASS::Cint
+@compat mxclassid(::Union{Type{Float64}, Type{Complex128}}) = mxDOUBLE_CLASS::Cint
+@compat mxclassid(::Union{Type{Float32}, Type{Complex64}}) = mxSINGLE_CLASS::Cint
 mxclassid(::Type{Int8})    = mxINT8_CLASS::Cint
 mxclassid(::Type{UInt8})   = mxUINT8_CLASS::Cint
 mxclassid(::Type{Int16})   = mxINT16_CLASS::Cint
@@ -384,7 +384,7 @@ function _copy_sparse_mat{V,I}(a::SparseMatrixCSC{V,I},
     ccall(:memcpy, Ptr{Void}, (Ptr{Void}, Ptr{Void}, UInt), pr_p, v, nnz * sizeof(V))
 end
 
-function mxarray{V<:Union{Float64,Bool},I}(a::SparseMatrixCSC{V,I})
+@compat function mxarray{V<:Union{Float64,Bool},I}(a::SparseMatrixCSC{V,I})
     m::Int = a.m
     n::Int = a.n
     nnz = length(a.nzval)

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -666,7 +666,7 @@ function jdict(mx::MxArray)
         throw(ArgumentError("jdict only applies to a single struct."))
     end
     nf = nfields(mx)
-    fnames = Array(String, nf)
+    fnames = Array(AbstractString, nf)
     fvals = Array(Any, nf)
     for i = 1 : nf
         fnames[i] = get_fieldname(mx, i)

--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -65,7 +65,7 @@ function get_paths()
 end
 get_paths()
 
-matlab_library(lib::String) =
+matlab_library(lib::AbstractString) =
     matlab_library_path == nothing ? lib : joinpath(matlab_library_path, lib)
 
 # libmx (loaded when the module is imported)

--- a/test/mxarray.jl
+++ b/test/mxarray.jl
@@ -57,13 +57,13 @@ a = mxempty()
 @mx_test_basic_types Float64 is_double
 @mx_test_basic_types Float32 is_single
 @mx_test_basic_types Int64   is_int64
-@mx_test_basic_types Uint64  is_uint64
+@mx_test_basic_types UInt64  is_uint64
 @mx_test_basic_types Int32   is_int32
-@mx_test_basic_types Uint32  is_uint32
+@mx_test_basic_types UInt32  is_uint32
 @mx_test_basic_types Int16   is_int16
-@mx_test_basic_types Uint16  is_uint16
+@mx_test_basic_types UInt16  is_uint16
 @mx_test_basic_types Int8    is_int8
-@mx_test_basic_types Uint8   is_uint8
+@mx_test_basic_types UInt8   is_uint8
 @mx_test_basic_types Bool    is_logical
 
 # complex arrays
@@ -288,7 +288,7 @@ a = mxstruct(s)
 delete(a)
 
 type TestType
-    name::String
+    name::AbstractString
     version::Float64
     data::Vector{Int}
 end
@@ -364,7 +364,7 @@ a = @compat Dict{Any,Any}("abc"=>10.0, "efg"=>[1, 2, 3], "xyz"=>"MATLAB")
 x = mxarray(a)
 y = jvariable(x)
 delete(x)
-@test isa(y, Dict{String, Any})
+@test isa(y, Dict{AbstractString, Any})
 
 @test y["abc"] == 10.0
 @test isequal(y["efg"], [1, 2, 3])


### PR DESCRIPTION
…ctString.

A minor disclaimer: I am not fully literate in Julia yet and therefor I might have made some mistake, but this should resolve some but not all the annoying warnings about deprecated types when using Matlab from the stable Julia v0.4+. (ie. As such no guarantees of functionality etc, are given by me or my employer).