### PR TITLE
Fix readall and isexecutable deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat
+Compat 0.7.9

--- a/src/mxbase.jl
+++ b/src/mxbase.jl
@@ -12,7 +12,7 @@ function get_paths()
 
     if matlab_homepath == ""
         if OS_NAME == :Linux
-            matlab_homepath = dirname(dirname(realpath(chomp(readall(`which matlab`)))))
+            matlab_homepath = dirname(dirname(realpath(chomp(readstring(`which matlab`)))))
         elseif OS_NAME == :Darwin
             apps = readdir("/Applications")
             filter!(app -> ismatch(r"^MATLAB_R[0-9]+[ab]\.app$", app), apps)
@@ -37,7 +37,7 @@ function get_paths()
 
     if OS_NAME != :Windows
         default_startcmd = joinpath(matlab_homepath, "bin", "matlab")
-        if !isexecutable(default_startcmd)
+        if !isfile(default_startcmd)
             error("The MATLAB path is invalid. Set the MATLAB_HOME evironmental variable to the MATLAB root.")
         end
         default_startcmd = "exec $(Base.shell_escape(default_startcmd)) -nosplash"


### PR DESCRIPTION
Switching `isexecutable` to `isfile` was mentioned previously here: https://github.com/JuliaLang/julia/pull/12819#issuecomment-140216135

It would also be nice to get a new tagged release as the current one predates the release of `0.4` and is stuffed with deprecation warnings.

Thanks,
Josh

