### PR TITLE
Add Warning if array is above 2GB

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -180,8 +180,13 @@ function put_variable(session::MSession, name::Symbol, v::MxArray)
         string(name),
         v,
     )
+
+    # The size limit for `put_variable` is 2GB according to the MATLAB documentation, but seems to be a bit higher in practice.
+    # https://www.mathworks.com/help/matlab/apiref/engputvariable.html
     ret != 0 && throw(
-        MEngineError("failed to put variable $(name) into MATLAB session (err = $ret)"),
+        MEngineError(
+            "failed to put variable $(name) into MATLAB session (err = $ret). Ensure the that the variable name does not conflict with internal MATLAB names and that the size of the variable is below the MATLAB limit of 2GB.",
+        ),
     )
     return nothing
 end

--- a/src/mxarray.jl
+++ b/src/mxarray.jl
@@ -256,6 +256,14 @@ mxarray(x::T) where {T<:MxComplexNum} = mxarray([x])
 # mxArray use Julia array's memory
 
 function mxarray(a::Array{T}) where {T<:MxRealNum}
+    # Check the array size
+    if sizeof(a) > 2 * 1024^3
+        @warn(
+            "Input array size exceeds the limit of 2 GB and is too large to be used with the MATLAB engine.",
+            maxlog = 1
+        )
+    end
+
     mx = mxarray(T, size(a))
     ccall(
         :memcpy,
@@ -269,6 +277,14 @@ function mxarray(a::Array{T}) where {T<:MxRealNum}
 end
 
 function mxarray(a::Array{T}) where {T<:MxComplexNum}
+    # Check the array size
+    if sizeof(a) > 2 * 1024^3
+        @warn(
+            "Input array size exceeds the limit of 2 GB and is too large to be used with the MATLAB engine.",
+            maxlog = 1
+        )
+    end
+
     mx = mxarray(T, size(a))
     na = length(a)
     rdat = unsafe_wrap(Array, real_ptr(mx), na)


### PR DESCRIPTION
This PR adds a warning if arrays larger than 2GB are used in `MATLAB.jl` since those are not supported by the MATLAB engine api.

I think, we can close #154 since there is not much we can do about this.

MATLAB docs:
https://de.mathworks.com/help/matlab/apiref/engputvariable.html