### PR TITLE
Make the startup flag "-nodisplay" optional

### DIFF
--- a/src/engine.jl
+++ b/src/engine.jl
@@ -5,8 +5,8 @@
 #   Session open & close
 #
 ###########################################################
-const default_startflag = "-nodisplay -nosplash -nodesktop" # no additional flags
-const default_matlabcmd = matlab_cmd * " -nodisplay -nosplash -nodesktop"
+const default_startflag = "-nodisplay"
+const default_matlabcmd = matlab_cmd * " -nosplash -nodesktop"
 # pass matlab flags directly or as a Vector of flags, i.e. "-a" or ["-a", "-b", "-c"]
 startcmd(flag::AbstractString=default_startflag) =
     isempty(flag) ? default_matlabcmd : default_matlabcmd * " " * flag


### PR DESCRIPTION
For showing figures matlab must be started without the "-nodisplay" flag. 